### PR TITLE
Adding missing -D option to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ List of options:
       formated items from the database.
    * -n, new: Extract valid items of a database to a new one. Output will be:
       /tmp/new_db.[ip,pag]
+   * -D, directory: Used with -n, expects to receive a directory path in which the
+      the resulting new_db.[ip,pag] files are placed.
    * -s, status: Print information about the table, such us the amount of items,
       amount of expired items and also the amount of malformed items that
       may be using space;


### PR DESCRIPTION
I found a problem with the -D option and noticed that it was missing from the Readme page.