### PR TITLE
Adding a check of the target directory (specified with -D) of the new database (-n).

### DIFF
--- a/modsec-sdbm-util.c
+++ b/modsec-sdbm-util.c
@@ -469,6 +469,18 @@ int main (int argc, char **argv)
         int ret = 0;
         char *file = argv[index];
         apr_sdbm_t *db = NULL;
+        apr_dir_t *db_dest_dir;
+
+        // test to see if the target directory exists
+        printf ("Checking target directory: %s\n", new_db_path);
+        ret = apr_dir_open(&db_dest_dir, new_db_path, pool);
+        if (ret != APR_SUCCESS) {
+            char errmsg[120];
+            p("Could not open target directory %s: %s\n", new_db_path, apr_strerror(ret, errmsg, sizeof errmsg));
+            goto that_is_all_folks;
+        }
+        apr_dir_close(db_dest_dir);
+        printf("Target directory exists.\n");
 
         printf ("Opening file: %s\n", file);
         ret = open_sdbm(pool, &db, argv[index]);


### PR DESCRIPTION
I found that when using -n and -D together if you specify a non-existent directory the util will segfault. This PR adds a check of the target directory right after the options are parsed and aborts with a message if it doesn't exist. We could add another option later to create the directory if anyone things that would be a nice feature.

The current output for reference is:
~~~
# modsec-sdbm-util /path/to/default_SESSION -n -D /tmp/testing
Opening file: /path/to/default_SESSION
Database ready to be used.
New database generated with valid keys at: /tmp/testing/new_db
Segmentation fault (core dumped)
~~~